### PR TITLE
Add i18n framework with Dutch translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "i18next": "^23.10.1",
+    "react-i18next": "^14.2.1",
+    "i18next-browser-languagedetector": "^7.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/Clients.tsx
+++ b/src/components/Clients.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { Search, Filter, Plus, Mail, Phone, MapPin, Tag, FileText, Calendar, PhoneCall, Folder } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const Clients: React.FC = () => {
+  const { t } = useTranslation();
   const [selectedClient, setSelectedClient] = useState<number | null>(null);
   const [activeDetailTab, setActiveDetailTab] = useState('info');
 
@@ -88,11 +90,11 @@ const Clients: React.FC = () => {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
-          <button 
+          <button
             onClick={() => setSelectedClient(null)}
             className="text-blue-600 hover:text-blue-800 font-medium"
           >
-            ← Back to Clients
+            ← {t('back_to_clients')}
           </button>
           <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors">
             <Plus size={16} />
@@ -178,7 +180,7 @@ const Clients: React.FC = () => {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Clients</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t('clients')}</h1>
           <p className="text-gray-600">Manage your client relationships and data</p>
         </div>
         <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors">

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { TrendingUp, DollarSign, Calendar, Mail, Phone, Clock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const Dashboard: React.FC = () => {
+  const { t } = useTranslation();
   const kpiCards = [
     { title: 'Open Deals', value: '127', change: '+12%', icon: TrendingUp, color: 'blue' },
     { title: 'Closed Deals', value: '43', change: '+8%', icon: DollarSign, color: 'green' },
@@ -40,7 +42,7 @@ const Dashboard: React.FC = () => {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t('dashboard')}</h1>
           <p className="text-gray-600">Welcome back! Here's what's happening with your business.</p>
         </div>
       </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { 
   LayoutDashboard, 
   Users, 
@@ -16,15 +17,16 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab }) => {
+  const { t } = useTranslation();
   const menuItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { id: 'clients', label: 'Clients', icon: Users },
-    { id: 'deals', label: 'Deals', icon: Handshake },
-    { id: 'tasks', label: 'Tasks', icon: CheckSquare },
-    { id: 'emails', label: 'Emails', icon: Mail },
-    { id: 'calls', label: 'Calls', icon: Phone },
-    { id: 'reports', label: 'Reports', icon: BarChart3 },
-    { id: 'settings', label: 'Settings', icon: Settings },
+    { id: 'dashboard', label: t('dashboard'), icon: LayoutDashboard },
+    { id: 'clients', label: t('clients'), icon: Users },
+    { id: 'deals', label: t('deals'), icon: Handshake },
+    { id: 'tasks', label: t('tasks'), icon: CheckSquare },
+    { id: 'emails', label: t('emails'), icon: Mail },
+    { id: 'calls', label: t('calls'), icon: Phone },
+    { id: 'reports', label: t('reports'), icon: BarChart3 },
+    { id: 'settings', label: t('settings'), icon: Settings },
   ];
 
   return (

--- a/src/components/TopNavigation.tsx
+++ b/src/components/TopNavigation.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { Search, Bell, Plus, User, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const TopNavigation: React.FC = () => {
+  const { t, i18n } = useTranslation();
+
+  const changeLang = (lng: string) => {
+    void i18n.changeLanguage(lng);
+  };
+
   return (
     <header className="bg-white shadow-sm border-b border-gray-200 px-6 py-4">
       <div className="flex items-center justify-between">
@@ -10,16 +17,16 @@ const TopNavigation: React.FC = () => {
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
             <input
               type="text"
-              placeholder="Search clients, deals, tasks..."
+              placeholder={t('search_placeholder')}
               className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />
           </div>
         </div>
-        
+
         <div className="flex items-center space-x-4">
           <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2 transition-colors">
             <Plus size={16} />
-            <span>New</span>
+            <span>{t('new')}</span>
           </button>
           
           <button className="relative p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
@@ -33,6 +40,10 @@ const TopNavigation: React.FC = () => {
             </div>
             <span className="text-gray-700 font-medium">John Doe</span>
             <ChevronDown size={16} className="text-gray-500" />
+          </div>
+          <div className="flex space-x-1">
+            <button onClick={() => changeLang('nl')} className="px-2 text-sm text-gray-600 hover:text-gray-900">NL</button>
+            <button onClick={() => changeLang('en')} className="px-2 text-sm text-gray-600 hover:text-gray-900">EN</button>
           </div>
         </div>
       </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,19 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import translationNL from './locales/nl/translation.json';
+import translationEN from './locales/en/translation.json';
+
+void i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'nl',
+    resources: {
+      nl: { translation: translationNL },
+      en: { translation: translationEN }
+    },
+    interpolation: { escapeValue: false }
+  });
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,13 @@
+{
+  "dashboard": "Dashboard",
+  "clients": "Clients",
+  "deals": "Deals",
+  "tasks": "Tasks",
+  "emails": "Emails",
+  "calls": "Calls",
+  "reports": "Reports",
+  "settings": "Settings",
+  "new": "New",
+  "search_placeholder": "Search clients, deals, tasks...",
+  "back_to_clients": "Back to Clients"
+}

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -1,0 +1,13 @@
+{
+  "dashboard": "Dashboard",
+  "clients": "Klanten",
+  "deals": "Deals",
+  "tasks": "Taken",
+  "emails": "E-mails",
+  "calls": "Gesprekken",
+  "reports": "Rapporten",
+  "settings": "Instellingen",
+  "new": "Nieuw",
+  "search_placeholder": "Zoek in klanten, deals, taken...",
+  "back_to_clients": "Terug naar klanten"
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- integrate i18next with browser language detection
- add Dutch and English translation files
- hook i18n into React app
- translate menu items, search placeholder and a few titles
- provide language switcher in top navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c510d40e0832c8db81fefcbdd8bd7